### PR TITLE
Resolve issues resulting from testing reported by VGOVICH

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2025-07-24
+
+### Features
+- Add external_dependencies to manifest to prevent installation if woocommerce Python library is missing
+
+### Fix
+- Fix UOM creation using wrong field (factor_inv) should be factor
+- Fix Delivery Methods product.product creation causing duplicates due to woocommerce_product_site_url not setting
+- Fix V18 specific product changes: product no longer a [type] but a combination of [type] = consu and [is_storable] = True
+
 ## 2025-07-21
 
 ### Fix

--- a/woocommerce_sync/__manifest__.py
+++ b/woocommerce_sync/__manifest__.py
@@ -7,7 +7,10 @@
     'website': 'https://github.com/roboes/odoo-woocommerce-sync',
     'category': 'Connectors',
     # 'version': '16.0.1.2',
-    'version': '18.0.1.2',
+    'version': '18.0.1.3',
+    "external_dependencies": {
+        "python": ["woocommerce"],
+    },
     'depends': ['account', 'contacts', 'queue_job', 'product', 'sale_management', 'stock'],
     'data': [
         'security/ir.model.access.csv',

--- a/woocommerce_sync/models/models.py
+++ b/woocommerce_sync/models/models.py
@@ -553,7 +553,7 @@ class WoocommerceConnector(models.Model):
         odoo_unit_of_measure = self.env['uom.uom'].search([('active', '=', True), ('name', '=', unit_of_measure_name)], limit=1)
 
         if not odoo_unit_of_measure:
-            odoo_unit_of_measure = self.env['uom.uom'].create({'name': unit_of_measure_name, 'category_id': self.env.ref('uom.uom_categ_unit').id, 'factor_inv': 1, 'uom_type': 'reference'})
+            odoo_unit_of_measure = self.env['uom.uom'].create({'name': unit_of_measure_name, 'category_id': self.env.ref('uom.uom_categ_unit').id, 'factor': 1, 'uom_type': 'reference'})
 
         return odoo_unit_of_measure
 
@@ -650,6 +650,7 @@ class WoocommerceConnector(models.Model):
                         'sale_ok': True,
                         'purchase_ok': False,
                         'list_price': 0.0,
+                        'woocommerce_product_site_url': woocommerce_sync_config.settings_woocommerce_connection_url,
                     },
                 )
 
@@ -674,7 +675,7 @@ class WoocommerceConnector(models.Model):
 
         elif version_info[0] == 18:
             odoo_products = self.env['product.product'].search(
-                [('woocommerce_product_site_url', '=', woocommerce_sync_config.settings_woocommerce_connection_url), ('active', '=', True), ('woocommerce_product_id', '!=', False), ('type', '=', 'product')],
+                [('woocommerce_product_site_url', '=', woocommerce_sync_config.settings_woocommerce_connection_url), ('active', '=', True), ('woocommerce_product_id', '!=', False), ('is_storable', '=', True)],
             )
 
         for product in odoo_products:
@@ -1000,7 +1001,6 @@ class WoocommerceConnector(models.Model):
                         'image_1920': odoo_product_image_featured,
                         'default_code': product_values['woocommerce_product_sku'],
                         'create_date': product_values['woocommerce_product_date_created_gmt'],
-                        # 'type': 'service' if product_values['woocommerce_product_service'] else 'product' if product_values['woocommerce_product_manage_stock'] else 'consu',
                         'description': 'Imported via Odoo-WooCommerce Sync',
                         'description_sale': product_values['woocommerce_product_description'],
                         'responsible_id': woocommerce_sync_config.settings_woocommerce_user_responsible.id,
@@ -1037,7 +1037,8 @@ class WoocommerceConnector(models.Model):
                     product_values['detailed_type'] = 'service' if product_values['woocommerce_product_service'] else 'product' if product_values['woocommerce_product_manage_stock'] else 'consu'
 
                 elif version_info[0] == 18:
-                    product_values['type'] = 'service' if product_values['woocommerce_product_service'] else 'product' if product_values['woocommerce_product_manage_stock'] else 'consu'
+                    product_values['type'] = 'service' if product_values['woocommerce_product_service'] else 'consu'
+                    product_values["is_storable"] = True if product_values["woocommerce_product_manage_stock"] else False
 
                 if odoo_product:
                     odoo_product.write(product_values)
@@ -1315,7 +1316,6 @@ class WoocommerceConnector(models.Model):
                                 'image_1920': odoo_product_variation_image_featured,
                                 'default_code': product_variation_values['woocommerce_product_variation_sku'],
                                 'create_date': product_variation_values['woocommerce_product_variation_date_created_gmt'],
-                                # 'type': ('service' if product_variation_values['woocommerce_product_variation_service'] else 'product' if product_variation_values['woocommerce_product_variation_manage_stock'] else 'consu'),
                                 'description': 'Imported via Odoo-WooCommerce Sync',
                                 'description_sale': product_variation_values['woocommerce_product_variation_description'],
                                 # Product status
@@ -1354,8 +1354,9 @@ class WoocommerceConnector(models.Model):
 
                         elif version_info[0] == 18:
                             product_variation_values['type'] = (
-                                'service' if product_variation_values['woocommerce_product_variation_service'] else 'product' if product_variation_values['woocommerce_product_variation_manage_stock'] else 'consu'
+                                'service' if product_variation_values['woocommerce_product_variation_service'] else 'consu'
                             )
+                            product_variation_values["is_storable"] = True if product_variation_values["woocommerce_product_variation_manage_stock"] else False
 
                         # Update the product template so that all attribute lines are considered and variants are created
                         odoo_product._create_variant_ids()
@@ -2070,7 +2071,7 @@ class WoocommerceConnector(models.Model):
                         product_values['manage_stock'] = True if product.detailed_type == 'product' else False
 
                     elif version_info[0] == 18:
-                        product_values['manage_stock'] = True if product.type == 'product' else False
+                        product_values['manage_stock'] = True if product.is_storable else False
 
                     # Check if product has multiple variants
                     if len(product.product_variant_ids) > 1:
@@ -2198,7 +2199,7 @@ class WoocommerceConnector(models.Model):
                                 variation_data['manage_stock'] = True if product.detailed_type == 'product' else False
 
                             elif version_info[0] == 18:
-                                variation_data['manage_stock'] = True if product.type == 'product' else False
+                                variation_data['manage_stock'] = True if product.is_storable else False
 
                             # Check if a variation with this SKU already exists
                             variation_existing = variations_by_sku.get(odoo_product_variant.default_code)


### PR DESCRIPTION
Referring to comments on #3 by VGOVICH below:

Following up on our woocommerce_sync module implementation on Odoo 18.0, we have identified and addressed several issues, and found some specific configurations on our Odoo instance.
Here's a brief summary:
ModuleNotFoundError: No module named 'woocommerce'
Issue: Python library missing.
Resolution: Installed woocommerce library into Odoo's virtual environment (/opt/odoo18/odoo-venv/).
Status: RESOLVED. WooCommerce API connection is now successful.
UnboundLocalError: odoo_product_unit_of_measure_dimension_id
Issue: Error during product sync due to missing/incorrect Unit of Measure (UoM) handling (e.g., "cm", "kg").
Findings:
"cm" and "kg" UoMs exist in Odoo, but "kg" had a duplicate. The duplicate "kg" (ID: 12) was manually archived.
Crucially, uom.uom.name field in our Odoo is char (string), not jsonb.
Resolution: Modified module code (models.py) to properly search and create UoMs using name as a string and factor instead of factor_inv for Odoo 17+ compatibility.
Status: FIX APPLIED. Awaiting full sync validation.
Duplicate "Shipping Product" creation
Issue: Multiple "Shipping Product for Free shipping" items were created in Odoo.
Cause: woocommerce_product_site_url field was not being set during product.product creation for delivery carriers, leading to re-creation.
Resolution: Added woocommerce_product_site_url to product.product creation in odoo_delivery_carrier_create_or_retrieve function. Existing duplicates were manually archived.
Status: FIX APPLIED. Awaiting full sync validation.
ValueError: Wrong value for product.template.type: 'product'
Issue: Odoo rejected 'product' as a value for product.template.type during product import.
Finding: Our Odoo 18.0's product.template.type field has non-standard allowed values: [('consu', 'Goods'), ('service', 'Service'), ('combo', 'Combo')]. 'product' is missing. This suggests another module or custom configuration altered this standard Odoo 18 field.
Resolution: Applied a workaround in module code: for storable products (those with stock management), product.template.type is now set to 'consu' instead of 'product'.
Status: WORKAROUND IN PLACE. This allows sync to proceed but may impact Odoo's stock logic if not the intended type for storable goods. Further insight into why our Odoo 18's type field is customized would be greatly appreciated.
Current Status: We have run a sync with these changes, and products are now appearing in Odoo, which is a significant improvement. We are continuously monitoring Odoo logs (tail -f /var/log/odoo/odoo.log) for any further issues.
Your feedback on these findings and the custom product.template.type field behavior would be very helpful.