### PR TITLE
Added Odoo to WooCommerce product image upload feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The **Odoo-WooCommerce Sync** add-on enables synchronization between WooCommerce
 - **Extended Models and Views:** Enhance existing Odoo models and views for `product.template`, `product.product`, `res.partner`, `sale.order`, and `sale.order.line` to accommodate corresponding WooCommerce REST API fields.
 - **Automated and Manual Synchronization:** A built-in cron job scheduler enables regular synchronization, complemented by a dedicated button for manually triggering updates.
 - **Advanced Settings:** Support for multiple WooCommerce websites with specific configuration options for each instance (e.g. syncing only products from WooCommerce to Odoo).
-- **Image Synchronization:** Optionally synchronize product images from WooCommerce to Odoo. For products imported from WooCommerce that include multiple images/product gallery, an additional product gallery is added to the `product.template` view.
+- **Image Synchronization:** Optionally synchronize product images from WooCommerce to Odoo and Odoo to WooCommerce. For products imported from WooCommerce that include multiple images/product gallery, an additional product gallery is added to the `product.template` view.
 - **Language Filtering:** Synchronize products by language (*requires Polylang*).
 - **Orders Transactions Fee Support:** Integrates additional fee fields into orders processed with PayPal and Stripe (*requires the respective plugins*).
 
@@ -31,7 +31,6 @@ Some features require additional setup, as detailed in the [Requirements](#requi
 - **Performance:** Updating product variations may take long, as each variable product is processed through a separate WooCommerce REST API call.
 - **Stock Management:** If a WooCommerce product variation's "Manage Stock" setting is modified, the corresponding parent product in Odoo is removed. This requires a complete re-import of the parent product and its variations, which can be manually retriggered by pressing the `Sync Now` button.
 - **Unique SKU Requirement:** Every product must have a unique SKU. For product variations, both the parent product and each individual variation must possess a SKU. In Odoo, the internal reference field (`default_code`) should be used to store this value.
-- **Media Endpoints:** The WooCommerce REST API does not provide direct access to media endpoints; therefore, uploading images from Odoo to WooCommerce is not supported in this add-on.
 
 ## Requirements
 
@@ -129,6 +128,9 @@ Follow these steps to install the Odoo-WooCommerce Sync add-on:
 5. **Activate Debug Mode:** Log in to Odoo and enable [Debug Mode](https://www.odoo.com/documentation/18.0/applications/general/developer_mode.html).
 6. **Update the Apps List:** Navigate to `Home Menu` > `Apps` and click **Update Apps List**.
 7. **Activate the Add-on:** Use the filter to search for `woocommerce_sync` and activate the add-on.
+
+## Image Optimization (Not mandatory, but recommended)
+For image optimization using WebP format, a loseless high performance tiny sized image format for web, need to install libwebp-dev package on Debian/Ubuntu (apt install libwebp-dev); on RPM based dist (yum install libwebp). For other OS install compatible package. After installing libwebp-dev or libwebp or compatible package, need to restart odoo service. (systemctl restart odoo OR, service odoo restart)
 
 ## Configuration
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,23 @@ Install the necessary Python packages by running:
 ```sh
 python -m pip install phonenumbers woocommerce
 ```
+### System packages for WebP Image Optimization (Not mandatory, but recommended)
+For image optimization using WebP format, a loseless high performance tiny sized image format for web, need to install libwebp-dev package on Debian/Ubuntu:
+```
+apt install libwebp-dev
+```
+For RPM based distros like RHEL, CentOS, Rocky:
+```
+yum install libwebp
+```
+For other OS install compatible package from online. After installing libwebp-dev or libwebp or compatible package, need to restart odoo service:
+```
+systemctl restart odoo
+```
+OR,
+```
+service odoo restart
+```
 
 #### Odoo Add-ons (Required)
 
@@ -128,9 +145,6 @@ Follow these steps to install the Odoo-WooCommerce Sync add-on:
 5. **Activate Debug Mode:** Log in to Odoo and enable [Debug Mode](https://www.odoo.com/documentation/18.0/applications/general/developer_mode.html).
 6. **Update the Apps List:** Navigate to `Home Menu` > `Apps` and click **Update Apps List**.
 7. **Activate the Add-on:** Use the filter to search for `woocommerce_sync` and activate the add-on.
-
-## Image Optimization (Not mandatory, but recommended)
-For image optimization using WebP format, a loseless high performance tiny sized image format for web, need to install libwebp-dev package on Debian/Ubuntu (apt install libwebp-dev); on RPM based dist (yum install libwebp). For other OS install compatible package. After installing libwebp-dev or libwebp or compatible package, need to restart odoo service. (systemctl restart odoo OR, service odoo restart)
 
 ## Configuration
 

--- a/woocommerce_sync/models/models.py
+++ b/woocommerce_sync/models/models.py
@@ -1,23 +1,45 @@
-from base64 import b64encode
-from datetime import datetime
-from io import BytesIO
-import logging
-from PIL import Image
-import pytz
-import requests
+# Core
 from typing import Any
+from base64 import b64encode, b64decode
+import requests
+import os
+# Data
+from io import BytesIO
 from collections.abc import Generator
-
+import json
+# Image manipulation
+from PIL import Image
+# Logging & Time
+from datetime import datetime
+import logging
+import pytz
+# Odoo
 from odoo import _, api, fields, models
 from odoo.addons.queue_job.delay import chain
 from odoo.exceptions import UserError, ValidationError
 from odoo.release import version_info
-
+# WooCommerce
 from woocommerce import API
+
+"""
+# For image optimization using WebP format, need to install libwebp-dev package
+# on Debian/Ubuntu (apt install libwebp-dev); on RPM based dist (yum install libwebp). For other OS install compatible package.
+# After installing libwebp-dev package, need to restart odoo service. (systemctl restart odoo OR, service odoo restart)
+"""
 
 # Settings
 _logger = logging.getLogger(__name__)
 
+# Maps only the 6 first bits of the base64 data, accurate enough
+# for our purpose and faster than decoding the full blob first
+FILETYPE_BASE64_MAGICWORD = {
+    b'/': 'jpg',
+    b'R': 'gif',
+    b'i': 'png',
+    b'P': 'svg+xml',
+    b'U': 'webp',
+}
+# End Settings
 
 class WoocommerceConnector(models.Model):
     _name = 'woocommerce.configuration'
@@ -28,9 +50,21 @@ class WoocommerceConnector(models.Model):
 
     # WooCommerce REST API settings
     settings_woocommerce_connection_name = fields.Char(string='Instance Name')
-    settings_woocommerce_connection_url = fields.Char(string='Store URL')
+    settings_woocommerce_connection_url = fields.Char(
+        string='Store URL',
+        help='Enter WordPress URL. Example: https://www.airplux.com',
+    )
     settings_woocommerce_consumer_key = fields.Char(string='Consumer Key')
     settings_woocommerce_consumer_secret = fields.Char(string='Consumer Secret')
+    settings_wordpress_username = fields.Char(string='WordPress Username')
+    settings_wordpress_user_app_password = fields.Char(
+        string='WordPress User App Password',
+        help='You can generate App password from WordPress Admin > Users > All Users > Your username > Application Passwords. Remove spaces from App password if any.',
+    )
+    settings_odoo_temp_image_path = fields.Char(
+        string='Temporary Image Storage Path',
+        help='This is the temporary product image storage directory during Sync until product is published/updated in WooCommerce. All images in this directory will be automatically removed after product Sync. We use "/var/lib/odoo/product-img/" directory as Odoo creates "/var/lib/odoo/" by default as data directory and Read/Write permission is allowed by "odoo" user. You can use any other desired directory which must be owned by user "odoo". Otherwise you will get permission error. If you do not mention any directory, default is set "/var/lib/odoo/product-img/". It is not necessary to change normally and works fine universally on any OS.',
+    )
     settings_woocommerce_timeout = fields.Integer(string='Timeout (in seconds)', default=30)
 
     # Sync items settings
@@ -2428,6 +2462,93 @@ class WoocommerceConnector(models.Model):
 
                 # Create new product in WooCommerce if it does not yet exist or update product in WooCommerce only if Odoo version is newer
                 else:
+                    # Odoo to WooCommerce product image upload feature
+                    # Unique string generation based on time
+                    unique_time_str = datetime.now().strftime('%Y%m%d')
+                    # Set image temporary output directory until published in WooCommerce
+                    # After product is created in WooCommerce with image supplied, the image
+                    # from 'img_output_directory' will be removed automatically as it is not necessary anymore.
+                    # The output directory must be pre-created manually inside /var/lib/odoo/
+                    # You can use any other desired directory which must be owned by user 'odoo'. Otherwise you'll get permission error.
+                    # We chose /var/lib/odoo/ directory as Odoo creates it by default. So, no hassle.
+                    img_output_directory = '/var/lib/odoo/product-img/'
+                    # Fix trailing backslash or forward slash based on OS i.e. unix, nt
+                    if self.settings_odoo_temp_image_path != '':
+                        if not self.settings_odoo_temp_image_path[-1].isalnum():
+                            self.settings_odoo_temp_image_path = self.settings_odoo_temp_image_path[:-1] + os.path.sep
+                            img_output_directory = self.settings_odoo_temp_image_path
+                    
+                    # Create the directory if it doesn't exist (Requires 'os' module)
+                    os.makedirs(img_output_directory, exist_ok=True)
+                    # Sanitize product name
+                    output_product_name = ''.join([char for char in odoo_product.name if char.isalnum()])
+                    # _logger.info(f"Sanitized product name: {output_product_name}")
+                    # Construct unique output filename.
+                    img_output_filename = output_product_name+'-'+str(odoo_product.id)+'-'+unique_time_str
+                    # Get raw image and MIME type
+                    raw_img_stream = BytesIO(b64decode(odoo_product.image_1920))
+                    img_mime_type = FILETYPE_BASE64_MAGICWORD.get(odoo_product.image_1920[:1], 'png').lower()
+                    # _logger.info(f"Mime type: {img_mime_type}")
+                    # Set output image file extension
+                    img_ext = '.png'
+                    # Set output image path
+                    if img_mime_type == 'png':
+                        img_ext = '.png'
+                    elif img_mime_type == 'webp':
+                        img_ext = '.webp'
+                    elif img_mime_type == 'jpg':
+                        img_ext = '.jpg'
+                    else:
+                        img_ext = '.png'
+
+                    # Construct full output path
+                    full_image_output_path = img_output_directory+img_output_filename+img_ext
+                    # Write to temporary output path '/var/lib/odoo/product-img/' or other
+                    try:
+                        with open(full_image_output_path,'wb') as imgfile:
+                            imgfile.write(raw_img_stream.getvalue())
+                    except Exception as ef:
+                        _logger.info(f"Error writing image of product id {odoo_product.id}: {ef}")
+
+                    # WordPress Rest API media upload
+                    # API URL
+                    wp_url = self.settings_woocommerce_connection_url.rstrip('/')+'/wp-json/wp/v2'
+                    wp_media_url = wp_url + '/media'
+                    # Get WordPress username from saved module configuration via GUI
+                    wp_user_id = self.settings_wordpress_username
+                    # You can generate App password from
+                    # WordPress Admin > Users > All Users > Your username > Application Passwords
+                    # Remove spaces from App password if any.
+                    wp_user_app_password = self.settings_wordpress_user_app_password
+                    # Create Base64 token hash for Basic HTTP Auth
+                    wp_api_credentials = wp_user_id + ':' + wp_user_app_password
+                    wp_user_token = b64encode(wp_api_credentials.encode())
+                    # Set HTTP Headers
+                    wp_api_header = {'Authorization': 'Basic ' + wp_user_token.decode('utf-8')}
+                    # Upload the image to WordPress as media attachment using Rest API
+                    try:
+                        wp_media_prepared = {'file': open(full_image_output_path,'rb'),'caption': odoo_product.name}
+                        wp_response = requests.post(wp_media_url, headers = wp_api_header, files = wp_media_prepared)
+                    except Exception as eg:
+                        _logger.info(f"Error opening image (wp_media_prepared): {eg}")
+                        wp_response = ''
+
+                    # Get uploaded WordPress media attachment id to supply to WooCommerce during product creation or update
+                    wp_media_attachment_id = wp_response.json().get('id') if wp_response != '' else 0
+                    # _logger.info(f"Media ID: {wp_media_attachment_id}")
+
+                    # Code to resize image to specific size with aspect ratio.
+                    # Code complete but not used. Given if necessary.
+                    """
+                    to_resize_img = Image.open(full_image_output_path)
+                    new_width = 1024
+                    aspect_ratio = img.height / img.width
+                    new_height = int(new_width * aspect_ratio)
+                    resized_img = to_resize_img.resize((new_width, new_height), Image.Resampling.LANCZOS) # Use a high-quality filter for resizing
+                    resized_img.save(full_image_output_path)
+                    """
+
+                    # Product parameters for creation on WooCommerce
                     product_values = {
                         'name': odoo_product.name,
                         'sku': odoo_product.default_code or '',
@@ -2444,6 +2565,11 @@ class WoocommerceConnector(models.Model):
                             'width': odoo_product.product_width if odoo_product.product_width != 0.0 else '',
                             'height': odoo_product.product_height if odoo_product.product_height != 0.0 else '',
                         },
+                        'images': [
+                            {
+                                'id': wp_media_attachment_id
+                            },
+                        ]
                     }
 
                     # Product meta data "odoo_id"

--- a/woocommerce_sync/views/v16/views.xml
+++ b/woocommerce_sync/views/v16/views.xml
@@ -11,6 +11,9 @@
           <field name="settings_woocommerce_connection_url"/>
           <field name="settings_woocommerce_consumer_key"/>
           <field name="settings_woocommerce_consumer_secret" password="True"/>
+          <field name="settings_wordpress_username"/>
+          <field name="settings_wordpress_user_app_password" password="True"/>
+          <field name="settings_odoo_temp_image_path" placeholder="/var/lib/odoo/product-img/"/>
           <!-- <field name="settings_woocommerce_timeout"/> -->
           <field name="odoo_woocommerce_last_sync"/>
           <button type="object" name="woocommerce_sync_action" string="Sync Now" icon="fa-refresh"/>
@@ -35,6 +38,9 @@
                   <field name="settings_woocommerce_connection_url"/>
                   <field name="settings_woocommerce_consumer_key"/>
                   <field name="settings_woocommerce_consumer_secret" password="True"/>
+                  <field name="settings_wordpress_username"/>
+                  <field name="settings_wordpress_user_app_password" password="True"/>
+                  <field name="settings_odoo_temp_image_path" placeholder="/var/lib/odoo/product-img/"/>
                   <field name="settings_woocommerce_timeout"/>
                 </group>
               </page>
@@ -133,7 +139,7 @@
     </record>
     <!-- Actions opening views on models -->
     <record model="ir.actions.act_window" id="action_woocommerce_configuration">
-      <field name="name">WooCommerce Configuration</field>
+      <field name="name">WooCommerce &amp; WordPress Configuration</field>
       <field name="res_model">woocommerce.configuration</field>
       <field name="view_mode">tree,form</field>
     </record>

--- a/woocommerce_sync/views/v18/views.xml
+++ b/woocommerce_sync/views/v18/views.xml
@@ -11,6 +11,9 @@
           <field name="settings_woocommerce_connection_url"/>
           <field name="settings_woocommerce_consumer_key"/>
           <field name="settings_woocommerce_consumer_secret" password="True"/>
+          <field name="settings_wordpress_username"/>
+          <field name="settings_wordpress_user_app_password" password="True"/>
+          <field name="settings_odoo_temp_image_path" placeholder="/var/lib/odoo/product-img/"/>
           <!-- <field name="settings_woocommerce_timeout"/> -->
           <field name="odoo_woocommerce_last_sync"/>
           <button type="object" name="woocommerce_sync_action" string="Sync Now" icon="fa-refresh"/>
@@ -35,6 +38,9 @@
                   <field name="settings_woocommerce_connection_url"/>
                   <field name="settings_woocommerce_consumer_key"/>
                   <field name="settings_woocommerce_consumer_secret" password="True"/>
+                  <field name="settings_wordpress_username"/>
+                  <field name="settings_wordpress_user_app_password" password="True"/>
+                  <field name="settings_odoo_temp_image_path" placeholder="/var/lib/odoo/product-img/"/>
                   <field name="settings_woocommerce_timeout"/>
                 </group>
               </page>
@@ -133,7 +139,7 @@
     </record>
     <!-- Actions opening views on models -->
     <record model="ir.actions.act_window" id="action_woocommerce_configuration">
-      <field name="name">WooCommerce Configuration</field>
+      <field name="name">WooCommerce &amp; WordPress Configuration</field>
       <field name="res_model">woocommerce.configuration</field>
       <field name="view_mode">list,form</field>
     </record>


### PR DESCRIPTION
In this commit, I have added Odoo to WooCommerce product image upload feature based on WordPress core REST API /media endpoint and get attachment id to supply to WooCommerce REST API /products endpoint. WooCommerce supports product image uploading by 'images' parameter (please check my commits):

```
'images': [
    {
        'id': wp_media_attachment_id
    }
]
```