### PR TITLE
fix(19.0): drop base_multi_image.owner from product.template _inherit

### DIFF
--- a/woocommerce_sync/models/models.py
+++ b/woocommerce_sync/models/models.py
@@ -87,8 +87,7 @@ if version_info[0] in [16, 18]:
 # Product
 class ProductTemplate(models.Model):
     _name = 'product.template'
-    _inherit = ['product.template', 'base_multi_image.owner']
-    # _inherit = 'product.template' # TODO Odoo v19
+    _inherit = 'product.template'
 
     # Override the existing 'default_code' field to remove the compute/inverse for multi-variant products, so it can be set manually
     default_code = fields.Char(string='Internal Reference', store=True)


### PR DESCRIPTION
## Problem

On the `19.0` branch, a clean install of `woocommerce_sync` aborts registry loading:

```
TypeError: Model 'product.template' inherits from non-existing model 'base_multi_image.owner'.
```

`woocommerce_sync/models/models.py` declares:

```python
class ProductTemplate(models.Model):
    _name = 'product.template'
    _inherit = ['product.template', 'base_multi_image.owner']
    # _inherit = 'product.template' # TODO Odoo v19
```

But `__manifest__.py` on this branch already dropped `base_multi_image` from `depends` (there is no Odoo 19 release of `base_multi_image`). Since the module is neither a dependency nor installable on Odoo 19, the `base_multi_image.owner` parent model is never registered, and `ProductTemplate` (which is declared at module top level, not gated by the `version_info[0] in [16, 18]` check) fails to build.

## Fix

Activate the intent already noted in the `# TODO Odoo v19` comment so `product.template` inherits only itself:

```python
    _inherit = 'product.template'
```

This is safe: the only other `base_multi_image` usage in the file (the image getter, ~line 192) is already guarded with `if 'base_multi_image.image' in self.env:`, so it cleanly no-ops when `base_multi_image` is absent.

## Testing

- Before: fresh Odoo 19 install/upgrade of `woocommerce_sync` → registry load fails with the `TypeError` above (500 on every request).
- After: registry loads, module installs/updates, WooCommerce product/order/stock sync and PDF reports work normally.

Only the `19.0` branch is affected; `16.0`/`18.0` keep `base_multi_image` in their `depends`.